### PR TITLE
Correct mistake in example

### DIFF
--- a/relaygram.example.yaml
+++ b/relaygram.example.yaml
@@ -51,7 +51,7 @@ irc:
 
 
   servers:
-    - "Freenode"
+    - "Freenode":
       hostname: "irc.freenode.net"
       port: 6667
       nickname: "TGBot"


### PR DESCRIPTION
Forget a ":" in the yaml config file, it don't compile without it
